### PR TITLE
Fixes schema.sql

### DIFF
--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS file (
 
 CREATE TABLE IF NOT EXISTS openFile (
    filePath     TEXT PRIMARY KEY,
-   userId       INT,
+   userId       INT UNIQUE,
    CONSTRAINT openFilefilepathtofilepath FOREIGN KEY (filePath) REFERENCES file(path)
 );
 


### PR DESCRIPTION
Adds `UNIQUE` to `openFile.userId` to fix the foreign key constraint on `activeUser`.