### PR TITLE
Add schema.sql to database's init directory

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - 5432:5432
     volumes:
       - filefly_db_data:/var/lib/postgresql
+      - ./db/schema.sql:/docker-entrypoint-initdb.d/init.sql
 
 volumes:
   filefly_db_data:


### PR DESCRIPTION
Turns out there's a directory that can run sql files and shell scripts on init. This PR adds our schema to that directory to automatically populate the database